### PR TITLE
Add Codex support while preserving Claude workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,177 @@
+# Codex Paper Proofreading Agent
+
+## Purpose
+
+Use this repository as a two-phase proofreading system for robotics and computer-vision papers written in LaTeX.
+
+The detailed, authoritative review instructions live in:
+
+- `prompts/01_latex_workspace_review.md`
+- `prompts/02_paper_proofreading.md`
+
+This `AGENTS.md` is a coordinator for Codex, not a replacement for those files.
+
+The operating principle is always the same:
+
+1. Detect issues first.
+2. Do not edit anything during detection.
+3. Wait for the user to choose what to fix.
+4. Apply only the approved fixes.
+
+Preserve the paper's technical meaning, claims, and author voice. Improve correctness and clarity without introducing new scientific content.
+
+## When To Use Which Workflow
+
+Choose the workflow based on the user's request.
+
+### Workflow 1: LaTeX Workspace Review
+
+Use this when the user asks for a workspace audit, LaTeX review, submission sanity check, preamble check, reference check, bibliography check, or similar infrastructure-focused proofreading.
+
+Primary checklist:
+- `prompts/01_latex_workspace_review.md`
+
+Focus areas:
+- preamble and package configuration
+- macro safety and naming consistency
+- references, labels, bibliography, figures, and hidden submission mistakes
+
+### Workflow 2: Paper Proofreading
+
+Use this when the user asks for paper proofreading, language review, conference-style reviewer feedback, clarity review, or final manuscript polishing.
+
+Primary checklist:
+- `prompts/02_paper_proofreading.md`
+
+Focus areas:
+- language and grammar
+- scientific clarity and overclaiming
+- structure, captions, notation, and final-manuscript polish
+
+### If Both Apply
+
+Run the workspace review first, then the paper proofreading pass.
+
+## Source Of Truth
+
+Treat the prompt files as the source of truth for review criteria and edge cases.
+
+- Use this `AGENTS.md` to decide which workflow to run and to preserve the two-phase behavior.
+- Use the prompt files for the actual checklist content.
+- If the prompt files are missing, say that the full review instructions are unavailable rather than pretending this file is sufficient on its own.
+
+## Required Review Behavior
+
+Before reporting findings, silently gather full context.
+
+### Files To Read
+
+When the user provides a root `.tex` file:
+
+1. Read the root file.
+2. Resolve every `\input{...}` and `\include{...}` recursively.
+3. Read shared preamble and macro files if they exist, especially `shortcuts.tex`, `macros.tex`, `commands.tex`, and `preamble.tex`.
+4. Read every referenced `.bib` file.
+5. Check referenced figures and tables for missing assets when doing the workspace audit.
+6. If the user provides a compiled PDF, use it during paper proofreading for figure placement, caption polish, and PDF-visible leftovers that source-only review would miss.
+
+Do not review only the top-level file unless the user explicitly asks for that narrower scope.
+
+## Two-Phase Protocol
+
+### Phase 1: Detection Only
+
+During Phase 1:
+
+- do not modify files
+- do not rewrite paragraphs
+- do not apply style changes proactively
+- report all findings with unique IDs like `[1]`, `[2]`, `[3]`
+
+For each finding, include:
+- severity
+- location
+- short diagnosis
+- why it matters
+- an actionable fix direction
+
+Prefer severity labels from the source prompts:
+- workspace review: use practical severity wording such as `CRITICAL`, `MAJOR`, `MINOR`, `STYLE` when helpful
+- paper proofreading: use `CRITICAL`, `MAJOR`, `MINOR`, `STYLE`
+
+If nothing is wrong, say so clearly and mention any remaining limits of the review, such as missing PDF or missing bibliography files.
+
+### Phase 2: Approved Fixes Only
+
+Only edit files after explicit approval such as:
+
+- `discard 3, 7, 12`
+- `fix all critical`
+- `fix 2, 4, 9`
+- `proceed with all`
+
+When fixing:
+
+- apply only the approved findings
+- keep edits minimal and localized
+- preserve meaning and notation
+- avoid introducing new terminology unless required for consistency
+- do not silently fix unapproved neighboring issues
+
+After edits, summarize what changed and note anything intentionally left untouched.
+
+## Output Style
+
+Keep the review direct, rigorous, and conference-oriented.
+
+- Prefer reviewer-grade feedback over generic copyediting.
+- Flag subtle issues, not only obvious grammar mistakes.
+- Be especially careful with unsupported claims, notation drift, citation misuse, and caption quality.
+- When an issue is definite, be decisive.
+- When an issue depends on venue style or missing context, say that explicitly.
+
+## Paper Editing Constraints
+
+Apply these whenever you edit manuscript text:
+
+- No em dashes in rewritten prose.
+- Prefer precise, concrete wording over vague intensifiers.
+- Avoid changing scientific claims unless the user explicitly asks for claim softening.
+- Preserve LaTeX structure, labels, and macros where possible.
+
+## High-Value Checks To Emphasize
+
+These are the recurring principles behind the repository and should always be preserved.
+
+### Detect First, Fix Later
+
+Never skip directly to edits when the user asked for proofreading or audit feedback.
+
+### Real Submission Risks
+
+Prioritize issues that hurt acceptance odds:
+- broken references or bibliography
+- missing figures or labels
+- awkward or incorrect captions
+- unsupported "significantly" or "state-of-the-art" claims
+- tense inconsistency in Related Work
+- notation inconsistency
+- hardcoded method names that should be macros
+- leftover TODOs, comments, review notes, or layout hacks
+
+### Non-Native Writer Awareness
+
+Be attentive to common high-level patterns:
+- nominalization
+- citation-as-subject errors
+- awkward filler phrases
+- inconsistent article or preposition use
+- unnatural compound adjectives and hyphenation
+
+Treat these as writing-quality issues, not as a reason to flatten the author's voice.
+
+## If This Setup Is Copied Into A Paper Workspace
+
+Copy `AGENTS.md` together with the `prompts/` directory.
+
+Do not copy only `AGENTS.md` unless you also inline the full prompt content into it.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
-    <h1>Awesome Claude Code — Paper Proofreading</h1>
-    <a href="https://github.com/LimHyungTae/awesome-claudecode-paper-proofreading"><img src="https://img.shields.io/badge/Claude_Code-Prompt-blueviolet?logo=anthropic" /></a>
+    <h1>Awesome Claude Code / Codex — Paper Proofreading</h1>
+    <a href="https://github.com/LimHyungTae/awesome-claudecode-paper-proofreading"><img src="https://img.shields.io/badge/Claude_Code_+_Codex-Dual_Compatible-2b6cb0" /></a>
     <br />
     <br />
     <p align="center"><img src="https://github.com/user-attachments/assets/b2a97cb8-8535-4beb-b6af-2f641d1962c9" alt="Demo" width="95%"/></p>
@@ -11,9 +11,11 @@ ______________________________________________________________________
 
 ## :rocket: Overview
 
-Two Claude Code prompts for rigorous proofreading of LaTeX research papers, designed for robotics and computer vision submissions at ICRA, RSS, CVPR, RA-L, and T-RO level.
+This repository is designed to work with **both Claude Code and Codex** while preserving the original proofreading philosophy.
 
-The workflow is **two-phase**: Claude detects and lists all issues with unique numbers `[1]`, `[2]`, `[3]`... — then waits. The user selects which issues to fix or discard before any file is modified.
+The detailed instructions live in two prompt files. You can use them directly in a session, or copy/merge them into Codex-oriented workspace instructions such as `AGENTS.md`.
+
+The workflow remains **two-phase**: the agent detects and lists all issues with unique numbers `[1]`, `[2]`, `[3]`..., then waits. The user selects which issues to fix or discard before any file is modified.
 
 ______________________________________________________________________
 
@@ -32,11 +34,21 @@ The review rules in these prompts reflect the standards expected at top robotics
 
 ______________________________________________________________________
 
-## :page_facing_up: Prompts
+## :page_facing_up: Files
+
+### [`AGENTS.md`](AGENTS.md)
+
+Optional Codex coordinator instructions for the workflow:
+
+- detects first and waits before editing
+- chooses between workspace audit and paper proofreading
+- reads the full LaTeX workspace recursively
+- applies only approved fixes in Phase 2
+- points Codex to the authoritative prompt files
 
 ### [`prompts/01_latex_workspace_review.md`](prompts/01_latex_workspace_review.md)
 
-**LaTeX infrastructure audit** — detects workspace-level errors before submission.
+**LaTeX infrastructure audit** — detailed checklist for workspace-level errors before submission.
 
 | Check | Description |
 |-------|-------------|
@@ -52,7 +64,7 @@ ______________________________________________________________________
 
 ### [`prompts/02_paper_proofreading.md`](prompts/02_paper_proofreading.md)
 
-**Paper content proofreading** — acts as a strict conference-level reviewer.
+**Paper content proofreading** — detailed checklist for strict conference-level review.
 
 | Category | Description |
 |----------|-------------|
@@ -70,14 +82,18 @@ ______________________________________________________________________
 
 ## :hammer: How to Use
 
-These prompts are used from **inside your paper workspace**, not from inside this repository.
-The `@` file reference in Claude Code resolves paths relative to the directory where `claude` is launched.
+There are two supported ways to use this repository.
 
 ### Setup — Clone this repo once
 
 ```bash
 git clone https://github.com/LimHyungTae/awesome-claudecode-paper-proofreading.git ~/awesome-claudecode-paper-proofreading
 ```
+
+### Option 1 — Claude Code direct prompt use
+
+These prompts are used from **inside your paper workspace**, not from inside this repository.
+The `@` file reference in Claude Code resolves paths relative to the directory where `claude` is launched.
 
 ### Step 1 — Navigate to your paper workspace and launch Claude Code
 
@@ -90,7 +106,7 @@ claude
 
 In the Claude Code session, reference the prompt by its **absolute path**, then attach your paper files:
 
-```
+```text
 @~/awesome-claudecode-paper-proofreading/prompts/01_latex_workspace_review.md
 
 @main.tex @shortcuts.tex
@@ -100,7 +116,7 @@ In the Claude Code session, reference the prompt by its **absolute path**, then 
 
 Provide the root `.tex` file and the compiled PDF. The prompt automatically instructs Claude to follow all `\input{...}` calls and read every included section file:
 
-```
+```text
 @~/awesome-claudecode-paper-proofreading/prompts/02_paper_proofreading.md
 
 @main.tex @paper.pdf
@@ -115,29 +131,54 @@ Provide the root `.tex` file and the compiled PDF. The prompt automatically inst
 
 After Phase 1 output, respond with:
 
-```
+```text
 discard 3, 7, 12    ← skip specific issues
 fix all critical    ← fix only CRITICAL issues
 proceed with all    ← fix everything
 ```
 
-### Alternative — Copy prompt into `CLAUDE.md`
+### Option 2 — Codex workspace setup with `AGENTS.md` plus `prompts/`
 
-If you want the prompt to activate automatically whenever you open a paper project with Claude Code, copy the relevant prompt content into a `CLAUDE.md` file at the root of your paper workspace:
+Copy `AGENTS.md` and the `prompts/` directory into your paper workspace:
 
 ```bash
-cp ~/awesome-claudecode-paper-proofreading/prompts/01_latex_workspace_review.md /path/to/your/paper/CLAUDE.md
+cp ~/awesome-claudecode-paper-proofreading/AGENTS.md /path/to/your/paper/AGENTS.md
+cp -R ~/awesome-claudecode-paper-proofreading/prompts /path/to/your/paper/
+```
+
+Launch Codex from the paper root so it can pick up `AGENTS.md`, then ask for the workflow you want:
+
+```
+Run the LaTeX workspace review on `main.tex`.
+```
+
+or
+
+```
+Proofread `main.tex` against `paper.pdf`.
 ```
 
 ______________________________________________________________________
 
 ## :bulb: Design Principles
 
-- **Detect first, fix later** — Claude never modifies files until the user explicitly confirms
+- **Detect first, fix later** — the agent never modifies files until the user explicitly confirms
 - **Modular categories** — each check is a labeled block; reorder or disable by editing the table at the top of each prompt
 - **Real-world patterns** — rules extracted from annotated paper reviews across ICRA, RA-L, AAAI, BMVC, and CVPR submissions
 - **Non-native writer aware** — covers patterns common in papers by Korean/Japanese researchers
 - **`figures/` vs `pics/`** — distinguishes final manuscript figures from raw image sources
+
+______________________________________________________________________
+
+## :computer: CI / Headless Use
+
+This setup also works in CI or other non-GUI environments as long as the agent runs from the paper workspace and sees the relevant instructions.
+
+Recommended pattern:
+
+1. Check out your paper repository.
+2. Copy in `AGENTS.md` plus `prompts/`, or inline the prompt content into one file.
+3. Ask the agent to run the workspace review or proofreading pass.
 
 ______________________________________________________________________
 

--- a/prompts/01_latex_workspace_review.md
+++ b/prompts/01_latex_workspace_review.md
@@ -1,4 +1,13 @@
-# LaTeX Workspace Review Prompt for Claude Code
+# LaTeX Workspace Review Prompt for Claude Code and Codex
+
+## Compatibility
+
+This file is designed to work in either environment:
+
+- attach or reference it directly in a Claude Code or Codex session
+- copy or merge it into a paper workspace's `AGENTS.md` or equivalent Codex workspace instructions
+
+Keep the review rules unchanged when reusing this file so the two-phase workflow stays intact.
 
 ## Purpose
 

--- a/prompts/02_paper_proofreading.md
+++ b/prompts/02_paper_proofreading.md
@@ -1,4 +1,13 @@
-# Paper Proofreading Prompt for Claude Code
+# Paper Proofreading Prompt for Claude Code and Codex
+
+## Compatibility
+
+This file is designed to work in either environment:
+
+- attach or reference it directly in a Claude Code or Codex session
+- copy or merge it into a paper workspace's `AGENTS.md` or equivalent Codex workspace instructions
+
+Keep the review rules unchanged when reusing this file so the two-phase workflow stays intact.
 
 ## Persona
 


### PR DESCRIPTION
## Summary
- add a repository-level `AGENTS.md` for Codex usage
- update the README to document both Claude Code and Codex workflows
- mark both proofreading prompt files as compatible with Claude Code and Codex

## Notes
- the Claude direct prompt flow remains intact
- Codex usage is documented separately via `AGENTS.md` plus `prompts/`